### PR TITLE
Update docs to use scoped package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,13 +9,13 @@ Composites [Maki](https://mapbox.com/maki) icons with a map marker and returns a
 ## Install
 
 ```
-npm install makiwich --save
+npm install @mapbox/makiwich --save
 ```
 
 ## Usage
 
 ```js
-var makiwich = require('makiwich');
+var makiwich = require('@mapbox/makiwich');
 var mapnik = require('mapnik');
 
 makiwich.generateMarker({


### PR DESCRIPTION
`makiwich` is a deprecated package, folks should be using the scoped version `@mapbox/makiwich`