### PR TITLE
ready release v0.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/makiwich",
-  "version": "0.0.9",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/makiwich",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Sandwich together Maki icons with a map marker",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It appears #7 did not make it into v0.0.9, because that version had already been published to the npm registry.

![image](https://user-images.githubusercontent.com/16272584/96937066-52658680-1495-11eb-836e-e488bbff8f0e.png)

Cutting a v0.0.10 branch to be able to release the lighter version of the package via npm.

cc/ @tristen 
