### PR TITLE
Changing the logic for symbol matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function generateMarker (options, callback) {
 
     if (options.symbol) {
         var symbolSize = `${options.symbol}-${size === 's' ? '11' : '15'}`;
-        if (!assets.parsedSVGs[symbolSize] && !/^[1-9a-z]\d{0,1}$/.test(options.symbol)) return callback(errcode(`Symbol ${options.symbol} not valid`, 'EINVALID'));
+        if (!assets.parsedSVGs[symbolSize]) return callback(errcode(`Symbol ${options.symbol} not valid`, 'EINVALID'));
 
         // Add the symbol to the base marker
         basePaths[3].path = assets.parsedSVGs[symbolSize].svg.path;

--- a/test/test.js
+++ b/test/test.js
@@ -169,6 +169,26 @@ tape('invalid symbol', (t) => {
     });
 });
 
+tape('invalid symbol with a number and a letter', (t) => {
+    makiwich({
+        symbol: 'a1'
+    }, (err, svg) => {
+        t.equal(err.message, 'Symbol a1 not valid');
+        t.equal(svg, undefined);
+        t.end();
+    });
+});
+
+tape('invalid symbol with uppercase letter', (t) => {
+    makiwich({
+        symbol: 'A'
+    }, (err, svg) => {
+        t.equal(err.message, 'Symbol A not valid');
+        t.equal(svg, undefined);
+        t.end();
+    });
+});
+
 tape('invalid tint', (t) => {
     makiwich({
         tint: '/'


### PR DESCRIPTION
[`!/^[1-9a-z]\d{0,1}$`](https://regex101.com/r/JeElhR/1/) regex logic passes the Invalid symbol such as `a1` as valid. My question here is: 

1) If all the symbols in makiwitch are being validated via`assets.parsedSVGs[symbolSize]` what is the purpose of the regex logic?

 If this is a way to validate the symbols twice for the purpose of error handling, the regex logic should be [`^([a-z]|[0-9]{1,2})$`](https://regex101.com/r/WDN7yi/1/) to handle cases to validate two digits numbers and invalidate `a1`.

To resolve this issue, I removed the regex logic altogether. 